### PR TITLE
chore: drop the decorator syntax

### DIFF
--- a/.changeset/stupid-lines-buy.md
+++ b/.changeset/stupid-lines-buy.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/enviconf": major
+---
+
+Remove support for decorators (`@enviprop`)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Inspired by https://github.com/caarlos0/env
 
 ## Example
 
-### Without decorators
 ```ts
 
 import { BaseConfig, EnviConfig, envfield } from "@labdigital/enviconf";
@@ -39,54 +38,4 @@ class SampleConfig extends BaseConfig {
 const config = SampleConfig.load()
 
 config.HTTP_PORT === 4000
-```
-
-
-### With decorators
-```ts
-
-import { BaseConfig, envprop } from "@labdigital/enviconf";
-
-class SampleConfig extends BaseConfig {
-  @envprop.string()
-  public readonly MY_STRING_VARIABLE: string = "default value";
-
-  @envprop.number()
-  public readonly MY_NUMBER_VARIABLE: number = 123;
-
-  // Read JSON values
-  @envprop.object()
-  public readonly MY_OBJECT_VALUE: object = { foo: "bar" };
-
-  @envprop.number({
-    // optional, defaults to false. Sets empty value if no env variable is set
-    optional: true,
-
-    // optional, defaults to false. Unsets the env variable after reading
-    unset: true,
-
-    // optional, env variable to read the value from, defaults to the property name
-    envName: "MY_OTHER_ENV_VARIABLE",
-
-    // optional, defaults to ", ". Allows setting a custom separator for array values
-    envSeparator: ", ",
-
-    // optional, defaults to undefined. Allows setting a custom validator, should
-    // throw an error if the value is invalid
-    validator:  (value: number) => value > 0,
-  })
-  public readonly ALL_OPTIONS: number = 123;
-}
-
-const config = SampleConfig.load({
-  // optional, path to the .env values, defaults to ".env"
-  path: ".env",
-
-  // optional, indicates if a .env file should be read, defaults to true
-  loadEnv: true,
-
-  // optional, if set, will be used as prefix for all env variables while
-  // falling back to the original name if the prefixed variable is not set
-  envPrefix: "MY_APP_",
-})
 ```


### PR DESCRIPTION
This pull request refactors the configuration handling system by removing the decorator-based approach (`@envprop`) and replacing it with a method-based configuration system (`config`). This simplifies the codebase, improves maintainability, and aligns the API with modern practices. The most important changes include the removal of decorators, updates to the `BaseConfig` class, and corresponding test updates.

### Codebase Simplification

* Removed the decorator-based configuration system (`@envprop`) and associated helper methods (`decorate`, `storePropertyOptions`, and `getConfigs`) from `src/index.ts`. The configuration is now defined using a `config` method that returns an `EnviConfig` object. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L9-R10) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L23-L68) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L100-R61) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L120-L139) [[5]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L231-R188)

* Updated the `BaseConfig` class in `src/index.ts` to use the `config` method for defining environment variable mappings, replacing the previous decorator-based approach.

### Test Updates

* Refactored all test cases in `src/index.test.ts` to remove the use of `@envprop` decorators and replace them with the new `config` method for defining environment variable configurations. This includes changes in initialization, validation, and inheritance test cases. [[1]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L17-R31) [[2]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L42-R63) [[3]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L64-R85) [[4]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L83-R106) [[5]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L96-R124) [[6]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L109-R142) [[7]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L126-R166) [[8]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L143-R188) [[9]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L155-L278)

### API Adjustments

* Consolidated the `envprop` and `envfield` APIs into a single `envfield` object in `src/index.ts`, simplifying the available API surface for defining environment variable configurations.