### PR TITLE
chore: add `disableUnset` flag

### DIFF
--- a/.changeset/neat-rocks-tan.md
+++ b/.changeset/neat-rocks-tan.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/enviconf": patch
+---
+
+Add the `disableUnset` flag to load, to disable unset functionality globally

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -193,6 +193,27 @@ describe("validate", () => {
 		expect(config.MY_SECRET_VARIABLE).toBe("some-secret");
 		expect(process.env.MY_SECRET_VARIABLE).toBeUndefined();
 	});
+
+	it("should override unset value after reading environment variable", () => {
+		vi.stubEnv("MY_SECRET_VARIABLE", "some-secret");
+
+		class SampleConfig extends BaseConfig {
+			public MY_SECRET_VARIABLE: string;
+
+			config(): EnviConfig {
+				return {
+					MY_SECRET_VARIABLE: envfield.string({ unset: true }),
+				};
+			}
+		}
+
+		const config = new SampleConfig();
+		config.load({
+			disableUnset: true,
+		});
+		expect(config.MY_SECRET_VARIABLE).toBe("some-secret");
+		expect(process.env.MY_SECRET_VARIABLE).toBeDefined();
+	});
 });
 
 describe("inheritance", () => {


### PR DESCRIPTION
This pull request introduces a new `disableUnset` flag to the `load` method in the `@labdigital/enviconf` package, allowing users to globally disable the `unset` functionality for environment variables. It also includes updates to the configuration options and tests to support this new feature.

### New Feature: `disableUnset` Flag

* Added a `disableUnset` flag to the `LoadOptions` type in `src/index.ts`, enabling users to globally disable the `unset` functionality for all properties. This is particularly useful for testing or development purposes.
* Updated the `BaseConfig` class to respect the `disableUnset` flag when determining whether to unset environment variables after loading.

### Configuration Enhancements

* Expanded the `FieldOptions` type in `src/index.ts` with detailed documentation for existing options such as `unset`, `envName`, and `envSeparator`, improving clarity for developers.

### Testing

* Added a new test case in `src/index.test.ts` to verify that the `disableUnset` flag prevents environment variables from being unset after being read.

### Documentation

* Updated the `.changeset/neat-rocks-tan.md` file to document the addition of the `disableUnset` flag and its functionality.